### PR TITLE
Removed doctype in pumpJSONND

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kachok
-A simple json-nd data pumper to elasticsearch; no backpressure support.
+A simple json-nd data pumper to elasticsearch; no backpressure support (yet!).
 Use it when logstash fails you or when you need a solid base to start from.
 
 

--- a/README.md
+++ b/README.md
@@ -23,29 +23,31 @@ Use it when logstash fails you or when you need a solid base to start from.
 
 
 ```
-py -3 kachok.py pumpJSONND --help
-WARNING: ujson not found, install it for better performance
-INFO: Showing help with the command 'kachok.py pumpJSONND -- --help'.
-
 NAME
-    kachok.py pumpJSONND
+    kachok.py pumpJSONND - Pump new-line delimited JSON documents to elasticsearch
 
 SYNOPSIS
     kachok.py pumpJSONND SELF INDEX <flags> [LOGFILES]...
 
+DESCRIPTION
+    Pump new-line delimited JSON documents to elasticsearch
+
 POSITIONAL ARGUMENTS
     SELF
     INDEX
+        elasticsearch index
     LOGFILES
+        list of files to import
 
 FLAGS
-    --batchsize=BATCHSIZE (required)
-    --doctype=DOCTYPE (required)
-    --errordir=ERRORDIR (required)
-
-NOTES
-    You can also use flags syntax for POSITIONAL ARGUMENTS
-    
+    --batchsize=BATCHSIZE
+        batch size per request
+    --doctype=DOCTYPE
+        document type
+    --errordir=ERRORDIR
+        directory where to output errors (if unspecified, outputs to same directory as file)
+    --progress=PROGRESS
+        display progress bar
   ```
 
 # Examples
@@ -55,5 +57,8 @@ NOTES
 
 ## Upload data 
 ```./kachok.py --endpoint=http://localhost:9200 pumpJSONND myindexname /path/to/files/*.json```
+
+## Authenticate using HTTP basic auth 
+```./kachok.py --username true --password groot --endpoint=http://localhost:9200 pumpJSONND myindexname /path/to/files/*.json```
 
 You can use glob syntax (e.g '**' for recursive)

--- a/kachok.py
+++ b/kachok.py
@@ -91,14 +91,14 @@ class Kachok(object):
             "Posted a batch of {} in {} seconds".format(len(batch), delta))
         return errors
 
-    def pumpJSONND(self, index, *logfiles, batchsize=3200, doctype="securitylogs", errordir=None,progress=True):
+    def pumpJSONND(self, index, *logfiles, batchsize=3200, errordir=None,progress=True):
         """
         Pump new-line delimited JSON documents to elasticsearch
         Args:
             index: elasticsearch index
             logfiles: list of files to import
             batchsize: batch size per request
-            doctype: document type
+            doctype: document type - outdated since ES 7.0
             errordir: directory where to output errors (if unspecified, outputs to same directory as file)
             progress: display progress bar
         """        
@@ -125,7 +125,8 @@ class Kachok(object):
             fp = open(filepath,encoding="utf-8",errors='ignore')
             path = "{}/_bulk".format(index)
             accum = []
-            head = json.dumps({"index": {"_index": index, "_type": doctype}})
+            # head = json.dumps({"index": {"_index": index, "_type": doctype}})
+            head = json.dumps({"index": {"_index": index}})
             errors = []
             i=0
             try: 


### PR DESCRIPTION
ES 7.0 no longer requires type_name i.e. "doctype" in this code